### PR TITLE
Allow dot in hostnames

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ SensuAdmin::Application.routes.draw do
   scope 'events' do
     match 'events_table' => 'events#events_table', :via => :get
     match 'modal_data' => 'events#modal_data', :via => :get
-    scope '/:client' do
+    scope '/:client', :constraints => { :client => /[\w.]+/ } do
       match '/silence' => 'events#silence_client', :via => :post
       match '/unsilence' => 'events#unsilence_client', :via => :post
       scope '/:check' do


### PR DESCRIPTION
This fixes #63. The issue was caused by hostnames that contain periods. The default Rails regex for matching parameters excludes dots, this modifies the constraint the for the `client` parameter to allow dots.

I also restructured the routes to make use of scopes, to avoid repeating the first part of the path, as well as the additional constraint, in each entry. 
