### PR TITLE
_apistatus.html.haml calls 'health' object which doesn't exist in sensu api 0.9.11

### DIFF
--- a/app/views/api/_apistatus.html.haml
+++ b/app/views/api/_apistatus.html.haml
@@ -1,8 +1,8 @@
 %div.row
   - api = Api.status
   - sensu_version = api.sensu['version']
-  - redis_health = api.health['redis']
-  - rabbitmq_health = api.health['rabbitmq']
+  - redis_health = api.redis['connected'] ? "ok" : "failed"
+  - rabbitmq_health = api.rabbitmq['connected'] ? "ok" : "failed"
   %span.badge.badge-info{:style => "margin-right: 5px;"}
     == API Version: #{sensu_version}
   - if redis_health == "ok"
@@ -10,10 +10,10 @@
       == Redis: #{redis_health.upcase}
   - else
     %span.badge.badge-important{:style => "margin-right: 5px;"}
-      == Redis: #{redis_health.upcase} 
+      == Redis: #{redis_health.upcase}.
   - if rabbitmq_health == "ok"
     %span.badge.badge-success{:style => "margin-right: 5px;"}
       == RabbitMQ: #{rabbitmq_health.upcase}
   - else
     %span.badge.badge-important{:style => "margin-right: 5px;"}
-      == RabbitMQ: #{rabbitmq_health.upcase} 
+      == RabbitMQ: #{rabbitmq_health.upcase}.


### PR DESCRIPTION
Sensu appears to have changed the `/info` api, to the extent that the response no longer contains a 'health' object. Given the _apistatus.html.haml view looks for this, a web request to /api/status generates a 500. I've put this small change in for 0.9.11, but this will probably break for 0.9.10 now.
