### PR TITLE
Fix api routing from namespace to scope

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ SensuAdmin::Application.routes.draw do
 
   match 'checks/:check/submit' => 'checks#submit_check', :via => :post
 
-  namespace :api do
+  scope 'api' do
     match '/status' => 'api#status', :via => :get
     match '/time' => 'api#time', :via => :get
     match '/setup' => 'api#setup', :via => :get


### PR DESCRIPTION
The /api routing was broken in a recent pull request - this restores it.
