### PR TITLE
Use non-american date format for event since ruby 1.9+ Time.prase does not support

### DIFF
--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -14,7 +14,7 @@ $ ->
 
     setPickers = ()->
       $('.timepicker').timepicker({  'step': 15, 'showDuration': true, 'timeFormat': 'g:ia', 'scrollDefaultNow': true })
-      $('.datepicker').datepicker({ 'autoclose': true, 'dateFormat': 'm/d/yy', 'format': 'mm/dd/yyyy' })
+      $('.datepicker').datepicker({ 'autoclose': true, 'dateFormat': 'd/m/yy', 'format': 'dd/mm/yyyy' })
 
     runPermanentHooks = ()->
       $(document).on 'keydown', '.silence-input', ->


### PR DESCRIPTION
If you deploy sensu-admin using ruby 1.9 you cant stash anything from the event panel because the date format is in american-date but Time.prase only supports d/m/yy.
