### PR TITLE
clear_expired_stashes was broken because expire_at is inside the hash content

### DIFF
--- a/app/models/stash.rb
+++ b/app/models/stash.rb
@@ -69,8 +69,8 @@ class Stash < Resting
 
   def self.clear_expired_stashes
     Stash.stashes.each do |v|
-      unless v['expire_at'].nil?
-        if Time.parse(v['expire_at']) < Time.now
+      unless v['content']['expire_at'].nil?
+        if Time.parse(v['content']['expire_at']) < Time.now
           puts "Clearing stash #{v['path']} due to expiration."
           destroy(v['path'])
         end


### PR DESCRIPTION
Sensu stash returns a hash that looks like this: 

{"path"=>"silence/dev-z2/ES-Cluster-Health", "content"=>{"description"=>"You must expired", "owner"=>"zuhaib@hipchat.com", "timestamp"=>1374184850, "expire_at"=>"2013-07-18T22:15:00+00:00"}}

So for the clear stash to work you must access ['content']['expire_at'].  Currently master is broken.

Tested on sensu 0.10.0
